### PR TITLE
test(executor): remove missing tx test

### DIFF
--- a/internal/agent/mock_agent/mock_agent.go
+++ b/internal/agent/mock_agent/mock_agent.go
@@ -8,7 +8,7 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	pb "github.com/meshplus/bitxhub-model/pb"
-	rpcx "github.com/meshplus/go-bitxhub-client"
+	go_bitxhub_client "github.com/meshplus/go-bitxhub-client"
 	reflect "reflect"
 )
 
@@ -36,10 +36,10 @@ func (m *MockAgent) EXPECT() *MockAgentMockRecorder {
 }
 
 // Appchain mocks base method
-func (m *MockAgent) Appchain() (*rpcx.Appchain, error) {
+func (m *MockAgent) Appchain() (*go_bitxhub_client.Appchain, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Appchain")
-	ret0, _ := ret[0].(*rpcx.Appchain)
+	ret0, _ := ret[0].(*go_bitxhub_client.Appchain)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -24,11 +24,11 @@ const (
 func TestExecute(t *testing.T) {
 	exec, ag, cli := prepare(t)
 	defer exec.storage.Close()
-	// set expect values
 
+	// set expect values
 	ret := &model.PluginResponse{
 		Status: true,
-		Result: nil,
+		Result: getIBTP(t, 1, pb.IBTP_INTERCHAIN),
 	}
 	ag.EXPECT().SendIBTP(gomock.Any()).Return(getReceipt(), nil).AnyTimes()
 	ag.EXPECT().GetIBTPByID(gomock.Any()).Return(getIBTP(t, 2, pb.IBTP_INTERCHAIN), nil).Times(1)
@@ -43,11 +43,6 @@ func TestExecute(t *testing.T) {
 		tx.TransactionHash = tx.Hash()
 		txs = append(txs, tx)
 	}
-
-	// add extra index tx for triggering getMissing
-	missingTx := getTx(t, uint64(3), pb.IBTP_INTERCHAIN)
-	missingTx.TransactionHash = missingTx.Hash()
-	txs = append(txs, missingTx)
 
 	// add replay tx for triggering ignore tx
 	ignoreTx := getTx(t, uint64(2), pb.IBTP_INTERCHAIN)


### PR DESCRIPTION
No need to test for out-of-order tx