### PR TITLE
fix(syncer): goroutine for verifying wrapper returned earlier

### DIFF
--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -286,18 +286,18 @@ func (syncer *MerkleSyncer) verifyWrapper(w *pb.MerkleWrapper) (bool, error) {
 
 	count := uint64(0)
 	var wg sync.WaitGroup
-	wg.Add(len(syncer.validators))
 
 	for _, validator := range syncer.validators {
 		sign, ok := w.Signatures[validator.String()]
 		if ok {
+			wg.Add(1)
 			go func(vlt types.Address, sign []byte) {
 				if isValid, _ := asym.Verify(asym.ECDSASecp256r1, sign, w.SignHash().Bytes(), vlt); isValid {
 					atomic.AddUint64(&count, 1)
 				}
+				wg.Done()
 			}(validator, sign)
 		}
-		wg.Done()
 	}
 
 	wg.Wait()


### PR DESCRIPTION
1. wrong usage of WaitGroup leads to that gorountine quits before it actully works on its job
2. add test case for verify-wrapper code coverage