### PR TITLE
fix(agent): fix pier queries original ibtp repetitively

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -15,7 +15,10 @@ import (
 )
 
 // agent is responsible for interacting with bitxhub
-var _ Agent = (*BxhAgent)(nil)
+var (
+	_               Agent = (*BxhAgent)(nil)
+	ErrIBTPNotFound       = fmt.Errorf("receipt from bitxhub failed")
+)
 
 // BxhAgent represents the necessary data for interacting with bitxhub
 type BxhAgent struct {
@@ -190,6 +193,10 @@ func (agent *BxhAgent) GetIBTPByID(id string) (*pb.IBTP, error) {
 		"GetIBTPByID", rpcx.String(id))
 	if err != nil {
 		return nil, err
+	}
+
+	if !receipt.IsSuccess() {
+		return nil, fmt.Errorf("%w: %s", ErrIBTPNotFound, string(receipt.Ret))
 	}
 
 	hash := types.Bytes2Hash(receipt.Ret)

--- a/internal/exchanger/exchanger.go
+++ b/internal/exchanger/exchanger.go
@@ -2,6 +2,7 @@ package exchanger
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -223,6 +224,7 @@ func (ex *Exchanger) sendIBTP(ibtp *pb.IBTP) error {
 			}
 
 			if !receipt.IsSuccess() {
+
 				entry.WithField("error", string(receipt.Ret)).Error("Send ibtp")
 				return nil
 			}
@@ -315,6 +317,9 @@ func (ex *Exchanger) queryIBTP(from string, idx uint64) (*pb.IBTP, error) {
 		case repo.RelayMode:
 			ibtp, err = ex.agent.GetIBTPByID(id)
 			if err != nil {
+				if errors.Is(err, agent.ErrIBTPNotFound) {
+					logger.Panicf("query ibtp by id %s from bitxhub: %s", id, err.Error())
+				}
 				return fmt.Errorf("query ibtp from bitxhub: %s", err.Error())
 			}
 		case repo.DirectMode:


### PR DESCRIPTION
When bitxhub and pier remove its store and restart, pier will query
inexistent ibtp from bitxhub constantly