### PR TITLE
fix(agent): fix pier queries original ibtp repetitively

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,9 +24,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.2.0
 	github.com/sirupsen/logrus v1.5.0
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.6.1
-	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d
 	github.com/tidwall/gjson v1.6.0

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -15,7 +15,10 @@ import (
 )
 
 // agent is responsible for interacting with bitxhub
-var _ Agent = (*BxhAgent)(nil)
+var (
+	_               Agent = (*BxhAgent)(nil)
+	ErrIBTPNotFound       = fmt.Errorf("receipt from bitxhub failed")
+)
 
 // BxhAgent represents the necessary data for interacting with bitxhub
 type BxhAgent struct {
@@ -166,6 +169,9 @@ func (agent *BxhAgent) GetIBTPByID(id string) (*pb.IBTP, error) {
 		return nil, err
 	}
 
+	if !receipt.IsSuccess() {
+		return nil, fmt.Errorf("%w: %s", ErrIBTPNotFound, string(receipt.Ret))
+	}
 	hash := types.Bytes2Hash(receipt.Ret)
 
 	response, err := agent.client.GetTransaction(hash.Hex())

--- a/internal/exchanger/exchanger.go
+++ b/internal/exchanger/exchanger.go
@@ -2,6 +2,7 @@ package exchanger
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -263,6 +264,9 @@ func (ex *Exchanger) queryIBTP(from string, idx uint64) (*pb.IBTP, error) {
 		case repo.RelayMode:
 			ibtp, err = ex.agent.GetIBTPByID(id)
 			if err != nil {
+				if errors.Is(err, agent.ErrIBTPNotFound) {
+					logger.Panicf("query ibtp by id %s from bitxhub: %s", id, err.Error())
+				}
 				return fmt.Errorf("query ibtp from bitxhub: %s", err.Error())
 			}
 		case repo.DirectMode:


### PR DESCRIPTION
When bitxhub and pier remove its store and restart, pier will query
inexistent ibtp from bitxhub constantly