### PR TITLE
fix(cmd): config direct peers separately

### DIFF
--- a/cmd/pier/init.go
+++ b/cmd/pier/init.go
@@ -91,7 +91,7 @@ var initCMD = cli.Command{
 				cli.StringSliceFlag{
 					Name:     "peers",
 					Usage:    "Specify counter party peers to connect",
-					Required: true,
+					Required: false,
 				},
 			},
 			Action: initPier,
@@ -109,7 +109,7 @@ var initCMD = cli.Command{
 				cli.StringSliceFlag{
 					Name:     "connectors",
 					Usage:    "Specify the remote union peers to connect",
-					Required: true,
+					Required: false,
 				},
 			},
 			Action: initPier,

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -227,3 +227,17 @@ func LoadNodePrivateKey(repoRoot string) (crypto.PrivateKey, error) {
 
 	return asym.PrivateKeyFromStdKey(privKey)
 }
+
+func ReadConfig(v *viper.Viper, path, configType string, config interface{}) error {
+	v.SetConfigFile(path)
+	v.SetConfigType(configType)
+	if err := v.ReadInConfig(); err != nil {
+		return err
+	}
+
+	if err := v.Unmarshal(config); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
- config direct peers using cmd:
```shell
pier config peers --addPier xxxx

// example:
pier --repo ./ config peers --addPier 127.0.0.1:4009#0xF0f6F772d68AC510dF925582f239A8cDE9e1156B
pier --repo ./ config peers --delPier 127.0.0.1:4009#0xF0f6F772d68AC510dF925582f239A8cDE9e1156B

```