### PR TITLE
Fix/genrate receipt fail

### DIFF
--- a/internal/exchanger/exchanger_test.go
+++ b/internal/exchanger/exchanger_test.go
@@ -91,6 +91,8 @@ func testNormalStartRelay(t *testing.T) {
 			ReceiptCounter:          map[string]uint64{fullToService: 1},
 			SourceReceiptCounter:    make(map[string]uint64),
 			InterchainCounter:       make(map[string]uint64)}, nil).AnyTimes()
+
+	mockAdaptRelay.EXPECT().GetServiceIDList().Return([]string{fullFromService}, nil).AnyTimes()
 	//mockAdaptRelay.EXPECT().QueryInterchain(gomock.Eq("1356:fabric:data")).
 	//	Return(&pb.Interchain{ID: "1356:fabric:transfer"}, nil).AnyTimes()
 


### PR DESCRIPTION
fix: bxh adapt get receipt err always retry
feat: if service registered in bxh, it must in broker's whiteList